### PR TITLE
Save and load env transitions

### DIFF
--- a/analysis/load_env_data.py
+++ b/analysis/load_env_data.py
@@ -1,60 +1,21 @@
-import pandas as pd
+"""
+Example script to load pickled env data
+"""
+
 from relaqs import RESULTS_DIR
-from relaqs.api import dm_fidelity
-import relaqs.api.gates as gates
+from relaqs.api import load_pickled_env_data
 
-import numpy as np
-from numpy.linalg import eigvalsh
+data_path = RESULTS_DIR + '2024-01-24_11-37-15_X/env_data.pkl'
 
-def load_and_analyze(data_path, U_target):
-    df = pd.read_csv(data_path) 
-    
-    fidelity = df.iloc[:, 0]
-    reward = df.iloc[:, 1]
-    actions = df.iloc[:, 2:4]
-    unitary = df.iloc[:, 4:]
+df = load_pickled_env_data(data_path)
 
-    max_fidelity_idx = fidelity.argmax()
-    max_fidelity = fidelity.iloc[max_fidelity_idx]
-    best_fidelity_unitary = np.array([complex(x) for x in unitary.iloc[max_fidelity_idx].tolist()]).reshape(4, 4)
+fidelity = df["Fidelity"]
+reward = df["Rewards"]
+actions = df["Actions"]
+unitary = df["Operator"]
+episode_id = df["Episode Id"]
 
-    print("Max fidelity:", max_fidelity)
-    print("Max unitary:", best_fidelity_unitary)
+max_fidelity_idx = fidelity.argmax()
+max_fidelity = fidelity.iloc[max_fidelity_idx]
 
-    zero = np.array([1, 0]).reshape(-1, 1)
-    zero_dm = zero @ zero.T.conjugate()
-    zero_dm_flat = zero_dm.reshape(-1, 1)
-
-    dm = best_fidelity_unitary @ zero_dm_flat
-    dm = dm.reshape(2, 2)
-    print("Density Matrix:\n", dm)
-
-    # Check trace = 1
-    dm_diagonal = np.diagonal(dm)
-    print("diagonal:", dm_diagonal)
-    trace = sum(np.diagonal(dm))
-    print("trace:", trace)
-
-    # # Check that all eigenvalues are positive
-    eigenvalues = eigvalsh(dm)
-    print("eigenvalues:", eigenvalues)
-    #assert (0 <= eigenvalues).all()
-
-    psi = U_target @ zero
-    true_dm = psi @ psi.T.conjugate()
-    print("true dm\n:", true_dm)
-
-    print("Density matrix fidelity:", dm_fidelity(true_dm, dm))
-
-if __name__ == "__main__":
-    data_path = RESULTS_DIR + '2023-07-21_13-34-31/env_data.csv' # H
-    #data_path = RESULTS_DIR + '2023-07-25_16-24-58/env_data.csv' # S
-    #data_path = RESULTS_DIR + '2023-07-25_22-32-31/env_data.csv' # X pi/4
-    #data_path = RESULTS_DIR + '2023-07-26_13-14-26/env_data.csv' # X
-    #data_path = RESULTS_DIR + '2023-07-26_13-47-46/env_data.csv' # Y
-    #data_path = RESULTS_DIR + '2023-08-02_09-10-09/env_data.csv' # Noiseless H
-    #data_path = RESULTS_DIR + '2023-08-02_09-48-04/env_data.csv' # Noiseless X
-    #data_path = RESULTS_DIR + '2023-08-02_11-24-32/env_data.csv' # H with element-wise reward
-
-    U_target = gates.H().get_matrix()
-    load_and_analyze(data_path, U_target)
+print("Max fidelity:", max_fidelity)

--- a/src/relaqs/api/__init__.py
+++ b/src/relaqs/api/__init__.py
@@ -1,4 +1,4 @@
 from .training import TrainRLLib
 from .callbacks import GateSynthesisCallbacks
 from .gates import Gate
-from .utils import gate_fidelity, dm_fidelity
+from .utils import gate_fidelity, dm_fidelity, load_pickled_env_data

--- a/src/relaqs/api/utils.py
+++ b/src/relaqs/api/utils.py
@@ -22,6 +22,10 @@ from relaqs import QUANTUM_NOISE_DATA_DIR
 from qutip.operators import *
 import relaqs.api.gates as gates
 
+def load_pickled_env_data(data_path):
+    df = pd.read_pickle(data_path)
+    return df
+
 gate_fidelity = lambda U, V: float(np.abs(np.trace(U.conjugate().transpose() @ V))) / (U.shape[0])
 
 def dm_fidelity(rho, sigma):

--- a/src/relaqs/environments/gate_synth_env_rllib_Haar.py
+++ b/src/relaqs/environments/gate_synth_env_rllib_Haar.py
@@ -81,7 +81,7 @@ class GateSynthEnvRLlibHaar(gym.Env):
         self.gamma_magnitude_max = 1.8 * np.pi / self.final_time / self.steps_per_Haar
         self.gamma_detuning_max = 0.05E9      #detuning of the control pulse in Hz 
         self.transition_history = []
-        self.episode_id = None
+        self.episode_id = 0
 
     def unitary_to_observation(self, U):
         return (
@@ -114,7 +114,7 @@ class GateSynthEnvRLlibHaar(gym.Env):
         self.U_array = []
         self.prev_fidelity = 0
         info = {}
-        self.episode_id = None
+        self.episode_id += 1
         return starting_observeration, info
 
     def step(self, action):
@@ -165,7 +165,7 @@ class GateSynthEnvRLlibHaar(gym.Env):
                 "detuning: " f"{action[2]:7.3f}"
             )
 
-        self.transition_history.append([fidelity, reward, action, self.U.flatten(), self.episode_id])
+        self.transition_history.append([fidelity, reward, action, self.U, self.episode_id])
         
         # Determine if episode is over
         truncated = False
@@ -238,7 +238,7 @@ class GateSynthEnvRLlibHaarNoisy(gym.Env):
         self.gamma_phase_max = 1.1675 * np.pi
         self.gamma_magnitude_max = 1.8 * np.pi / self.final_time / self.steps_per_Haar
         self.transition_history = []
-        self.episode_id = None
+        self.episode_id = 0
 
     def detuning_update(self):
         # Random detuning selection
@@ -293,7 +293,7 @@ class GateSynthEnvRLlibHaarNoisy(gym.Env):
         self.L_array = []
         self.U_array = []
         self.prev_fidelity = 0
-        self.episode_id = None
+        self.episode_id += 1
         self.relaxation_rate = self.get_relaxation_rate()
         self.detuning = 0
         self.detuning_update()
@@ -363,7 +363,7 @@ class GateSynthEnvRLlibHaarNoisy(gym.Env):
                 "phase: " f"{action[1]:7.3f}",
             )
 
-        self.transition_history.append([fidelity, reward, action.tolist(), self.U.flatten(), self.episode_id])
+        self.transition_history.append([fidelity, reward, action, self.U, self.episode_id])
 
         # Determine if episode is over
         truncated = False
@@ -469,6 +469,7 @@ class TwoQubitGateSynth(gym.Env):
         self.gamma_phase_max = 1.1675 * np.pi
         self.gamma_magnitude_max = 1.8 * np.pi / self.final_time / self.steps_per_Haar
         self.transition_history = []
+        self.episode_id = 0
 
     def detuning_update(self):
         # Random detuning selection
@@ -533,6 +534,7 @@ class TwoQubitGateSynth(gym.Env):
         self.detuning_update()
         starting_observeration = self.get_observation()
         info = {}
+        self.episode_id += 1
         return starting_observeration, info
 
     def step(self, action):
@@ -595,7 +597,7 @@ class TwoQubitGateSynth(gym.Env):
         #         "R: ", f"{reward:7.3f}",
         #     )
 
-        self.transition_history.append([fidelity, reward, *action, *self.U.flatten()])
+        self.transition_history.append([fidelity, reward, action, self.U, self.episode_id])
 
         # Determine if episode is over
         truncated = False

--- a/src/relaqs/save_results.py
+++ b/src/relaqs/save_results.py
@@ -5,6 +5,7 @@ from relaqs import RESULTS_DIR
 from typing import List, Dict
 import json
 import numpy as np
+import pandas as pd
 from types import MappingProxyType
 
 l = frozenset([])
@@ -59,43 +60,11 @@ class SaveResults():
         return path
 
     def save_env_transitions(self):
-        second_row = self.env.transition_history[1]
-        fidelity_n_space = len(str(second_row[0]))
-        fidelity = 'Fidelity'
-        fidelity = fidelity + ' '*(fidelity_n_space - len(fidelity))
-
-        rewards_n_space = len(str(second_row[1]))
-        rewards = 'Rewards'
-        rewards = rewards + ' '*(rewards_n_space - len(rewards))
-
-        actions_n_space = len(str(second_row[2]))
-        actions = 'Actions'
-        actions =  actions + ' '*(actions_n_space - len(actions))
-        
-        flattened_u_n_space = len( ','.join(map(str, second_row[3])))
-        flattened_u = 'Flattened U'
-        flattened_u =  flattened_u + ' '*(flattened_u_n_space - len(flattened_u))
+        columns = ['Fidelity', 'Rewards', 'Actions', 'Operator', 'Episode Id']
+        df = pd.DataFrame(self.env.transition_history, columns=columns)
+        df.to_pickle(self.save_path + "env_data.pkl") # easier to load than csv
+        df.to_csv(self.save_path + "env_data.csv", index=False) # backup in case pickle doesn't work
     
-        episode_n_space = len(str(second_row[4]))
-        episode = 'Episode Id'
-        episode = episode + ' '*(episode_n_space - len(episode)) 
-
-        column_headers = [fidelity, rewards, actions, flattened_u, episode] 
-        with open(self.save_path + "env_data.csv", "w") as f:
-            writer = csv.writer(f)
-            writer.writerow(column_headers)
-          
-            # Iterate over each row in the transition history
-            for row in self.env.transition_history:
-                # Convert the 'flattened_u' list within the row to a string
-                # Assuming 'flattened_u' is the fourth item in the row
-                row[3] = ','.join(map(str, row[3]))
-                # Write the modified row to the CSV
-                writer.writerow(row)
-
-        with open(self.save_path + "env_data.npy", "wb") as f:
-            np.save(f, np.array(self.env.transition_history))
-
     def save_train_results_data(self):
         with open(self.save_path+'train_results_data.json', 'w') as f:
             json.dump(self.results,f, cls=NpEncoder)


### PR DESCRIPTION
* `save_env_transitions` in `src/relaqs/save_results.py` now converts environment transitions into a pandas DataFrame and saves in `.pkl` and `.csv` formats. Fixes #25 
* `src/relaqs/api/utils.py` now has a `load_pickled_env_data` method which returns a pandas DataFrame
* `analysis/load_env_data.py` provides and example of loading pickled environment data
* `self.env_transitions` in `src/relaqs/environments/gate_synth_env_rllib_Haar.py` has been refactored according to the new methods for saving and loading
* `self.episode_id` in `src/relaqs/environments/gate_synth_env_rllib_Haar.py` is now set to 0 and incremented in `reset`. Fixes #23 