### PR TITLE
Plotting index bug fix

### DIFF
--- a/src/relaqs/environments/noisy_single_qubit_env.py
+++ b/src/relaqs/environments/noisy_single_qubit_env.py
@@ -109,9 +109,9 @@ class NoisySingleQubitEnv(SingleQubitEnv):
 
         self.update_transition_history(fidelity, reward, action)
 
-        self.Haar_update()
-
         truncated, terminated = self.is_episode_over(fidelity)
+
+        self.Haar_update()
 
         info = {}
         return (self.state, reward, terminated, truncated, info)

--- a/src/relaqs/environments/noisy_two_qubit_env.py
+++ b/src/relaqs/environments/noisy_two_qubit_env.py
@@ -177,9 +177,9 @@ class NoisyTwoQubitEnv(NoisySingleQubitEnv):
 
         self.update_transition_history(fidelity, reward, action)
       
-        self.Haar_update()
-
         truncated, terminated = self.is_episode_over(fidelity)
+
+        self.Haar_update()
 
         info = {}
         return (self.state, reward, terminated, truncated, info)

--- a/src/relaqs/environments/single_qubit_env.py
+++ b/src/relaqs/environments/single_qubit_env.py
@@ -164,9 +164,9 @@ class SingleQubitEnv(gym.Env):
 
         self.update_transition_history(fidelity, reward, action)
         
-        self.Haar_update()
-
         truncated, terminated = self.is_episode_over(fidelity)
+        
+        self.Haar_update()
 
         info = {}
         return (self.state, reward, terminated, truncated, info)

--- a/src/relaqs/plot_data.py
+++ b/src/relaqs/plot_data.py
@@ -90,12 +90,17 @@ def plot_data(save_dir, episode_length, figure_title=''):
     avg_final_fidelity_per_episode = []
     avg_final_infelity_per_episode = []
     avg_sum_of_rewards_per_episode = []
-    for i in range (1, len(final_fidelity_per_episode)):
+    for i in range (len(final_fidelity_per_episode)):
         start = i - rolling_average_window if (i - rolling_average_window) > 0 else 0
-        avg_final_fidelity_per_episode.append(np.mean(final_fidelity_per_episode[start: i]))
-        avg_final_infelity_per_episode.append(np.mean(final_infelity_per_episode[start: i]))
-        avg_sum_of_rewards_per_episode.append(np.mean(sum_of_rewards_per_episode[start: i]))
-    
+        avg_final_fidelity_per_episode.append(np.mean(final_fidelity_per_episode[start: i + 1]))
+        avg_final_infelity_per_episode.append(np.mean(final_infelity_per_episode[start: i + 1]))
+        avg_sum_of_rewards_per_episode.append(np.mean(sum_of_rewards_per_episode[start: i + 1]))
+
+    # Round averages to prevent numerical error when plotting
+    rounding_precision = 6
+    avg_final_fidelity_per_episode = np.round(avg_final_fidelity_per_episode, rounding_precision)
+    avg_final_infelity_per_episode = np.round(avg_final_infelity_per_episode, rounding_precision)
+    avg_sum_of_rewards_per_episode = np.round(avg_sum_of_rewards_per_episode, rounding_precision)
 
     # -------------------------------> Plotting <-------------------------------------
     rcParams['font.family'] = 'serif'
@@ -131,5 +136,5 @@ def plot_data(save_dir, episode_length, figure_title=''):
     plt.savefig(save_dir + "plot.png")
 
 if __name__ == "__main__":
-    save_dir = RESULTS_DIR + "2024-02-23_19-34-58_H/"
+    save_dir = RESULTS_DIR + "2024-02-27_19-31-17_H/"
     plot_data(save_dir, episode_length=2, figure_title="")

--- a/src/relaqs/plot_data.py
+++ b/src/relaqs/plot_data.py
@@ -90,8 +90,8 @@ def plot_data(save_dir, episode_length, figure_title=''):
     avg_final_fidelity_per_episode = []
     avg_final_infelity_per_episode = []
     avg_sum_of_rewards_per_episode = []
-    for i in range (len(final_fidelity_per_episode)):
-        start = i - rolling_average_window if (i - rolling_average_window) >= 0 else 0
+    for i in range (1, len(final_fidelity_per_episode)):
+        start = i - rolling_average_window if (i - rolling_average_window) > 0 else 0
         avg_final_fidelity_per_episode.append(np.mean(final_fidelity_per_episode[start: i]))
         avg_final_infelity_per_episode.append(np.mean(final_infelity_per_episode[start: i]))
         avg_sum_of_rewards_per_episode.append(np.mean(sum_of_rewards_per_episode[start: i]))
@@ -112,7 +112,6 @@ def plot_data(save_dir, episode_length, figure_title=''):
     ax1.set_title("a)", loc='left', fontsize='medium')
     ax1.set_xlabel("Episodes")
 
-
     # ----> infidelity <----
     ax2.plot(final_infelity_per_episode, color="r")
     ax2.plot(avg_final_infelity_per_episode, color="k")
@@ -132,5 +131,5 @@ def plot_data(save_dir, episode_length, figure_title=''):
     plt.savefig(save_dir + "plot.png")
 
 if __name__ == "__main__":
-    save_dir = RESULTS_DIR + "2023-09-19_14-21-02/"
-    plot_data(save_dir, episode_length=2, figure_title="Random Target Gate")
+    save_dir = RESULTS_DIR + "2024-02-23_19-34-58_H/"
+    plot_data(save_dir, episode_length=2, figure_title="")


### PR DESCRIPTION
Fixes an indexing bug that would cause the first value in `avg_final_fidelity_per_episode` to be `NaN`.

Branched off of `cf/episode-end` ([PR](https://github.com/akataba/rl-repo/pull/41)). 

Also fixes plotting issue that occurred when plotting high-precision values. We were getting this high precision values from the averaged arrays when fidelity was constant and the averaged values had some numerical error that caused them to be off by about 1e-16. Solved this issue by rounding the averaged arrays.

Closes #39 