### PR TITLE
More plot fixes

### DIFF
--- a/src/relaqs/plot_data.py
+++ b/src/relaqs/plot_data.py
@@ -73,7 +73,7 @@ def plot_data(save_dir, episode_length, figure_title=''):
     current_fidelity = fidelities[0]
     current_reward_sum = rewards[0]
     for i in range(len(episode_ids)):
-        if episode_ids[i] != current_episode_id:
+        if (episode_ids[i] != current_episode_id) or (i == len(episode_ids) - 1):
             final_fidelity_per_episode.append(current_fidelity)
             final_infelity_per_episode.append(1 - current_fidelity)
             sum_of_rewards_per_episode.append(current_reward_sum)

--- a/src/relaqs/plot_data.py
+++ b/src/relaqs/plot_data.py
@@ -56,33 +56,32 @@ def plot_results(save_dir, figure_title=""):
 def plot_data(save_dir, episode_length, figure_title=''):
     """ Currently works for constant episode_length """
     #---------------------- Getting data from files  <--------------------------------------
-    try:
-        with open(save_dir + "env_data.npy", "rb") as f:
-            df = np.load(f)
-            fidelities = df[:, 0]
-            rewards = df[:, 1]
-    except:
-        df = pd.read_csv(save_dir + "env_data.csv", header=0)
-        fidelities = np.array(df.iloc[:,0])
-        rewards = np.array(df.iloc[:,1])
-
-
+    df = pd.read_csv(save_dir + "env_data.csv", header=0)
+    fidelities = np.array(df.iloc[:,0])
+    rewards = np.array(df.iloc[:,1])
+    episode_ids = np.array(df.iloc[:,4])
 
     print("max fidelity: ", max(fidelities))
     print("max reward: ", max(rewards))
 
+    # --------> Get fidelity, infidelity, and reward from the last step of the episode <--------
     final_fidelity_per_episode = []
     final_infelity_per_episode = []
     sum_of_rewards_per_episode = []
 
-    # there is probably a numpy way to speed this up
-    n_transitions = len(fidelities)
-    for i in range(episode_length, n_transitions, episode_length):
-        episode_start_index = i - episode_length
-        episode_end_index = i - 1 # 0-indexing
-        final_fidelity_per_episode.append(fidelities[episode_end_index])
-        final_infelity_per_episode.append(1 - fidelities[episode_end_index])
-        sum_of_rewards_per_episode.append(np.sum(rewards[episode_start_index : episode_end_index + 1])) # +1 to include end of episode
+    current_episode_id = episode_ids[0]
+    current_fidelity = fidelities[0]
+    current_reward_sum = rewards[0]
+    for i in range(len(episode_ids)):
+        if episode_ids[i] != current_episode_id:
+            final_fidelity_per_episode.append(current_fidelity)
+            final_infelity_per_episode.append(1 - current_fidelity)
+            sum_of_rewards_per_episode.append(current_reward_sum)
+            current_reward_sum = 0
+        current_episode_id = episode_ids[i]
+        current_fidelity = fidelities[i]
+        current_reward_sum += rewards[i]
+    # ------------------------------------------------------------------------------------------
 
     # ----------------------> Moving average <--------------------------------------
     # Fidelity


### PR DESCRIPTION
@choihrM3 noticed an indexing issue when selecting the last-step fidelities/rewards from an episode. This indexing issue is caused because in the scripts `alg_config.build()` calls the `step` function of the environment one time, and thus adds to the environment's `transition_history` list and makes the previous logic for indexing off by one.

This PR uses `episode_id` to select the fidelity and reward from the last step of each episode for plotting. This should be more robust.

This PR also removes the try/except code for loading .npy files, which to the best of my knowledge are unused.