### PR TITLE
detuning, delta, hamiltonian difference

### DIFF
--- a/src/relaqs/environments/noisy_single_qubit_env.py
+++ b/src/relaqs/environments/noisy_single_qubit_env.py
@@ -81,7 +81,7 @@ class NoisySingleQubitEnv(SingleQubitEnv):
         # gamma is the complex amplitude of the control field
         gamma_magnitude, gamma_phase, alpha = self.parse_actions(action)
 
-        self.hamiltonian_update(alpha, gamma_magnitude, gamma_phase)
+        self.hamiltonian_update(self.detuning, alpha, gamma_magnitude, gamma_phase)
         self.H_tot_upate(num_time_bins)
 
         self.operator_update(num_time_bins)

--- a/src/relaqs/environments/single_qubit_env.py
+++ b/src/relaqs/environments/single_qubit_env.py
@@ -86,8 +86,9 @@ class SingleQubitEnv(gym.Env):
         self.episode_id += 1
         return starting_observeration, info
     
-    def hamiltonian_update(self, alpha, gamma_magnitude, gamma_phase):
-        H = self.hamiltonian(self.delta, alpha, gamma_magnitude, gamma_phase)
+    #def hamiltonian_update(self, alpha, gamma_magnitude, gamma_phase):
+    def hamiltonian_update(self, delta, alpha, gamma_magnitude, gamma_phase):
+        H = self.hamiltonian(delta, alpha, gamma_magnitude, gamma_phase)
         self.H_array.append(H)
 
     def H_tot_upate(self, num_time_bins):
@@ -134,7 +135,7 @@ class SingleQubitEnv(gym.Env):
         # Get actions
         gamma_magnitude, gamma_phase, alpha = self.parse_actions(action)
 
-        self.hamiltonian_update(alpha, gamma_magnitude, gamma_phase)
+        self.hamiltonian_update(self.delta, alpha, gamma_magnitude, gamma_phase)
         self.H_tot_upate(num_time_bins)
 
         # U update


### PR DESCRIPTION
@akataba found a bug where in the 2 qubit environment an error can occur when computing the Hamiltonian if `self.delta` is a list; `self.detuning` should be passed instead.

This PR fixes this issue.

We may want to wait on merging this PR until after we decide whether to remove `self.delta` from the 1-qubit environment.