### PR TITLE
noise parameter and hamiltonian refactor

### DIFF
--- a/src/relaqs/environments/single_qubit_env.py
+++ b/src/relaqs/environments/single_qubit_env.py
@@ -45,7 +45,7 @@ class SingleQubitEnv(gym.Env):
         self.prev_fidelity = 0
         self.gamma_phase_max = 1.1675 * np.pi
         self.gamma_magnitude_max = 1.8 * np.pi / self.final_time / self.steps_per_Haar
-        self.gamma_detuning_max = 0.05E9 # detuning of the control pulse in Hz
+        self.alpha_max = 0.05E9 # detuning of the control pulse in Hz
         self.transition_history = []
         self.episode_id = 0
 
@@ -123,7 +123,7 @@ class SingleQubitEnv(gym.Env):
     def parse_actions(self, action):
         gamma_magnitude = self.gamma_magnitude_max / 2 * (action[0] + 1)
         gamma_phase = self.gamma_phase_max * action[1]
-        alpha = self.gamma_detuning_max * action[2]
+        alpha = self.alpha_max * action[2]
         return gamma_magnitude, gamma_phase, alpha
     
     def update_transition_history(self, fidelity, reward, action):

--- a/src/relaqs/environments/single_qubit_env.py
+++ b/src/relaqs/environments/single_qubit_env.py
@@ -84,10 +84,6 @@ class SingleQubitEnv(gym.Env):
         self.episode_id += 1
         return starting_observeration, info
     
-    # def hamiltonian_update(self, alpha, gamma_magnitude, gamma_phase):
-    #     H = self.hamiltonian(alpha, gamma_magnitude, gamma_phase)
-    #     self.H_array.append(H)
-    
     def hamiltonian_update(self, num_time_bins, *hamiltonian_args):
         H = self.hamiltonian(*hamiltonian_args)
         self.H_array.append(H)
@@ -135,7 +131,6 @@ class SingleQubitEnv(gym.Env):
         gamma_magnitude, gamma_phase, alpha = self.parse_actions(action)
 
         self.hamiltonian_update(num_time_bins, alpha, gamma_magnitude, gamma_phase)
-        #self.H_tot_upate(num_time_bins)
 
         # U update
         self.U = self.U_initial.copy()


### PR DESCRIPTION
* Renames `gamma_detuning_max` to `alpha_max` per issue: #21 
* Removes `delta` from the noiseless environment
* Renames `delta` to `detuning_list` in the noisy environment. This makes the relationship clearer between the list of detuning values to sample from and the current detuning (`self.detuning`).
* Refactor of `hamiltonian_update` to include `H_tot_upate` and uses a `*hamiltonian_args` argument to allow for modular use with hamiltonians that have different input args.

Closes #21